### PR TITLE
Adds support for AJV Keywords + conditional schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "accepts": "^1.3.8",
     "ajv": "^8.11.0",
     "ajv-formats": "^2.1.1",
+    "ajv-keywords": "^5.1.0",
     "busboy": "^1.6.0",
     "connect": "^3.7.0",
     "content-type": "^1.0.4",

--- a/src/plugin.router/router.js
+++ b/src/plugin.router/router.js
@@ -1,5 +1,6 @@
 import Ajv from "ajv"
 import addFormats from "ajv-formats"
+import addKeywords from "ajv-keywords"
 import { pathToRegexp } from "path-to-regexp"
 import { count, reduce, findWith, merge, pluck, is, isEmpty } from "@asd14/m"
 
@@ -34,6 +35,8 @@ export default {
         "regex",
       ],
     })
+
+    addKeywords(ajv, ["regexp", "transform"])
 
     const { default: defaultRouteSchema } = await import("./default.schema.js")
     const routes = []

--- a/tests/index.js
+++ b/tests/index.js
@@ -37,6 +37,7 @@ test("blocks :: init with defaults", async t => {
       routes: [
         await import("./routes/no-schema.route.js"),
         await import("./routes/with-schema.route.js"),
+        await import("./routes/with-keywords.route.js"),
         await import("./routes/no-authenticate.route.js"),
         await import("./routes/no-authorize.route.js"),
         await import("./routes/dont-authenticate.route.js"),
@@ -57,8 +58,8 @@ test("blocks :: init with defaults", async t => {
 
     t.deepEquals(
       plugins.Router.count(),
-      12,
-      "given [11 custom routes] should [load default /ping and all custom]"
+      13,
+      "given [12 custom routes] should [load default /ping and all custom]"
     )
 
     t.deepEquals(
@@ -223,6 +224,22 @@ test("blocks :: init with defaults", async t => {
         body: { parsed: "with qs", another: "value" },
       },
       "given [form encoded body and content type] should [parse body with qs]"
+    )
+
+    t.deepEqual(
+      await POST(`${API_URL}/with-keywords`, {
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+        },
+        body: "title=%20UP%20CASED%20&foo=foobar",
+      }),
+      {
+        message: "Hello Plugin World!",
+        query: {},
+        params: {},
+        body: { foo: "foobar", title: "up cased" },
+      },
+      "given [form encoded with custom keywords] should [transform and validate data inside schema with added functionalities from ajv-keywords]",
     )
 
     t.deepEqual(

--- a/tests/index.js
+++ b/tests/index.js
@@ -38,6 +38,7 @@ test("blocks :: init with defaults", async t => {
         await import("./routes/no-schema.route.js"),
         await import("./routes/with-schema.route.js"),
         await import("./routes/with-keywords.route.js"),
+        await import("./routes/with-conditional-schema.route.js"),
         await import("./routes/no-authenticate.route.js"),
         await import("./routes/no-authorize.route.js"),
         await import("./routes/dont-authenticate.route.js"),
@@ -58,8 +59,8 @@ test("blocks :: init with defaults", async t => {
 
     t.deepEquals(
       plugins.Router.count(),
-      13,
-      "given [12 custom routes] should [load default /ping and all custom]"
+      14,
+      "given [13 custom routes] should [load default /ping and all custom]"
     )
 
     t.deepEquals(
@@ -240,6 +241,40 @@ test("blocks :: init with defaults", async t => {
         body: { foo: "foobar", title: "up cased" },
       },
       "given [form encoded with custom keywords] should [transform and validate data inside schema with added functionalities from ajv-keywords]",
+    )
+
+    t.deepEqual(
+      await POST(`${API_URL}/with-conditional-schema`, {
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "x-api-version": "1.0.0",
+        },
+        body: "foo=1",
+      }),
+      {
+        message: "Hello Plugin World!",
+        query: {},
+        params: {},
+        body: { foo: "1" },
+      },
+      "given [a versioned schema based on header] should [use one schema or the other based on the API header value]",
+    )
+
+    t.deepEqual(
+      await POST(`${API_URL}/with-conditional-schema`, {
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          "x-api-version": "2.4.0",
+        },
+        body: "foo=1",
+      }),
+      {
+        message: "Hello Plugin World!",
+        query: {},
+        params: {},
+        body: { foo: 1 },
+      },
+      "given [a versioned schema based on header] should [use one schema or the other based on the API header value]",
     )
 
     t.deepEqual(

--- a/tests/routes/with-conditional-schema.route.js
+++ b/tests/routes/with-conditional-schema.route.js
@@ -1,0 +1,19 @@
+import schema from "./with-conditional-schema.schema.js"
+
+export default {
+  method: "POST",
+  path: "/with-conditional-schema",
+  schema,
+  authenticate: (/* plugins */) => (/* req */) => true,
+  authorize: (/* plugins */) => (/* req */) => true,
+  action:
+    ({ Good }) =>
+    ({ ctx }) => {
+      return {
+        message: Good.getMessage(),
+        params: ctx.params,
+        query: ctx.query,
+        body: ctx.body,
+      }
+    },
+}

--- a/tests/routes/with-conditional-schema.schema.js
+++ b/tests/routes/with-conditional-schema.schema.js
@@ -1,0 +1,56 @@
+export default {
+  type: "object",
+  properties: {
+    headers: {
+      type: "object",
+      required: ["x-content-type"],
+      properties: {
+        "x-content-type": {
+          enum: ["application/x-www-form-urlencoded"],
+        },
+        "x-api-version": { type: "string" },
+      },
+    },
+  },
+  if: {
+    properties: {
+      headers: {
+        type: "object",
+        properties: {
+          "x-api-version": {
+            type: "string",
+            // <= 2.3.0
+            pattern:
+              "^([01]\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)|2\\.[0-2]\\.(?:0|[1-9]\\d*)|2\\.3\\.0)$",
+          },
+        },
+      },
+    },
+  },
+  then: {
+    properties: {
+      body: {
+        type: "object",
+        // additionalProperties: false,
+        properties: {
+          foo: {
+            type: "string",
+          },
+        },
+      },
+    },
+  },
+  else: {
+    properties: {
+      body: {
+        type: "object",
+        // additionalProperties: false,
+        properties: {
+          foo: {
+            type: "number",
+          },
+        },
+      },
+    },
+  },
+}

--- a/tests/routes/with-keywords.route.js
+++ b/tests/routes/with-keywords.route.js
@@ -1,0 +1,19 @@
+import schema from "./with-keywords.schema.js"
+
+export default {
+  method: "POST",
+  path: "/with-keywords",
+  schema,
+  authenticate: (/* plugins */) => (/* req */) => true,
+  authorize: (/* plugins */) => (/* req */) => true,
+  action:
+    ({ Good }) =>
+    ({ ctx }) => {
+      return {
+        message: Good.getMessage(),
+        params: ctx.params,
+        query: ctx.query,
+        body: ctx.body,
+      }
+    },
+}

--- a/tests/routes/with-keywords.schema.js
+++ b/tests/routes/with-keywords.schema.js
@@ -1,0 +1,26 @@
+export default {
+  headers: {
+    type: "object",
+    required: ["x-content-type"],
+    properties: {
+      "x-content-type": {
+        enum: ["application/x-www-form-urlencoded"],
+      },
+    },
+  },
+
+  body: {
+    type: "object",
+    // additionalProperties: false,
+    properties: {
+      foo: {
+        type: "string",
+        regexp: "/foo/i",
+      },
+      title: {
+        type: "string",
+        transform: ["trim", "toLowerCase"],
+      },
+    },
+  },
+}


### PR DESCRIPTION
Coming from #5, rebased on top of #7 

This PR brings the current version I plan to use in production for a while to upstream:

* [X] Adds ajv-keywords with the comments from ajv-keywords 
* [x] Support for conditionals on the schemas.

On the last one, the current implementation assumes the schema has a structure with a limited number of predefined of keywords (headers, body, query ...), but will not allow for conditionals such as if: and then: ([see more here](https://json-schema.org/understanding-json-schema/reference/conditionals.html#if-then-else)). That feature is particularly useful in a versioned API, if we want to maintain backwards compatibility without carrying too much schema weigh around.

I hope the test explains it well. The implementation is kind of simple, we may want to generalize it a bit.